### PR TITLE
fix: namespace filtering not working with matchExact selector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,9 +96,9 @@ build: fmt vet check-go-target check-version ## Build CLI binary.
 	go build -o bin/hitman-$(GOOS)-$(GOARCH) cmd/main.go
 	@sed -i -E 's/(version: )v[0-9.]+/\1{VERSION}/' ./internal/cmd/version/version.go
 
-.PHONY: run
+.PHONY: run fmt vet
 run: fmt vet ## Run a controller from your host.
-	go run ./cmd/main.go
+	go run ./cmd/main.go run $(ARGS)
 
 # If you wish to build the manager image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -64,12 +64,13 @@ func (p *Processor) SyncResources() (err error) {
 
 		resourceRaw := p.Client.Resource(gvr)
 
-		// TODO: This is not fully working. Using fieldSelector is potentially better
+		//
+		resourceList, err := resourceRaw.List(globals.ExecContext.Context, v1.ListOptions{})
 		if configResource.Target.Namespace.MatchExact != "" {
-			resourceRaw.Namespace(configResource.Target.Namespace.MatchExact)
+			resourceList, err = resourceRaw.Namespace(configResource.Target.Namespace.MatchExact).
+				List(globals.ExecContext.Context, v1.ListOptions{})
 		}
 
-		resourceList, err := resourceRaw.List(globals.ExecContext.Context, v1.ListOptions{})
 		if err != nil {
 			globals.ExecContext.Logger.Infof("error listing resources of type '%s' in namespace '%s': %s",
 				gvr.String(), configResource.Target.Namespace, err)


### PR DESCRIPTION
**Bug Fix: Namespace Filtering Not Working with matchExact**

**Description of the Bug**

The matchExact option in the target configuration for namespace selection was not working as expected. When specified, it wasn't filtering the targets and instead was capturing all namespaces.

**Root Cause**

In the original code, the namespace filtering was not being applied correctly because the result of resourceRaw.Namespace() was being discarded

**Solution**

The fix chains the Namespace() and List() calls together to properly apply the namespace filter

**Why This Fixes the Issue**

- The Namespace() method returns a new interface that must be used for subsequent operations

- By chaining Namespace().List(), we ensure the listing operation is scoped to the specified namespace

- When no exact namespace is specified, it falls back to listing across all namespaces