### PR TITLE
chore: add SPDX Apache-2.0 license headers to source files

### DIFF
--- a/api/v1alpha1/config_types.go
+++ b/api/v1alpha1/config_types.go
@@ -1,18 +1,5 @@
-/*
-Copyright 2024.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 package v1alpha1
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package cmd
 
 import (

--- a/internal/cmd/errors.go
+++ b/internal/cmd/errors.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package cmd
 
 import (

--- a/internal/cmd/help/help.go
+++ b/internal/cmd/help/help.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package help
 
 import (

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package run
 
 import (

--- a/internal/cmd/version/version.go
+++ b/internal/cmd/version/version.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package version
 
 import (

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/internal/globals/globals.go
+++ b/internal/globals/globals.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package globals
 
 import (

--- a/internal/globals/utils.go
+++ b/internal/globals/utils.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package globals
 
 import "strings"

--- a/internal/kubernetes/kubernetes.go
+++ b/internal/kubernetes/kubernetes.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package kubernetes
 
 import (

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package processor
 
 import (

--- a/internal/template/functions.go
+++ b/internal/template/functions.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package template
 
 import (


### PR DESCRIPTION
Add the standard two-line SPDX header to every source file in the repository so
the Apache-2.0 license is machine-readable per file:

```
SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
SPDX-License-Identifier: Apache-2.0
```

Where a longer Apache/copyright boilerplate header already existed, it was
replaced by these two short lines. Shebangs and Go build constraints are
preserved. This is a comments-only change; the build is unaffected.
